### PR TITLE
Refactor banner server driven

### DIFF
--- a/StreetCare/StreetCare.xcodeproj/project.pbxproj
+++ b/StreetCare/StreetCare.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		71B0D5CB2B9225670061033B /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71B0D5CA2B9225670061033B /* Badge.swift */; };
 		71FA51032BCEC4B300D0DA6C /* AfterOutreachView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FA51022BCEC4B300D0DA6C /* AfterOutreachView.swift */; };
 		71FA51052BD1909500D0DA6C /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FA51042BD1909500D0DA6C /* SplashView.swift */; };
+		74CD87FD2D4DE955000E5DBD /* LandingScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CD87FC2D4DE955000E5DBD /* LandingScreenViewModel.swift */; };
 		74FE994C2CC9F23F00D0C5D0 /* EventEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE994B2CC9F23F00D0C5D0 /* EventEnums.swift */; };
 		74FE994F2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE994E2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift */; };
 		74FE99512CC9FFAB00D0C5D0 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE99502CC9FFAB00D0C5D0 /* EventCardView.swift */; };
@@ -188,6 +189,7 @@
 		71B0D5CA2B9225670061033B /* Badge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
 		71FA51022BCEC4B300D0DA6C /* AfterOutreachView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfterOutreachView.swift; sourceTree = "<group>"; };
 		71FA51042BD1909500D0DA6C /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
+		74CD87FC2D4DE955000E5DBD /* LandingScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingScreenViewModel.swift; sourceTree = "<group>"; };
 		74FE994B2CC9F23F00D0C5D0 /* EventEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEnums.swift; sourceTree = "<group>"; };
 		74FE994E2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCommunityModel.swift; sourceTree = "<group>"; };
 		74FE99502CC9FFAB00D0C5D0 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
@@ -353,13 +355,13 @@
 		4CB65E4C29DA6D8500684BD1 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				74CD87FB2D4DE943000E5DBD /* LandingScreen */,
 				74FE994D2CC9FEDB00D0C5D0 /* CommunityEvents */,
 				4C7136B92A01F2A60060EB7D /* Profile */,
 				4C17ED4F2A00A3390013EF52 /* Visit Log */,
 				4CB65DA429D0DEEE00684BD1 /* MainTabBarView.swift */,
 				C2C7DDB62D31E762006A8CD1 /* ChapterMebershipForm.swift */,
 				C26F78C62CE4635F00AAE187 /* OutreachFormView.swift */,
-				4CB65D9129D016AE00684BD1 /* LandingScreenView.swift */,
 				71FA51022BCEC4B300D0DA6C /* AfterOutreachView.swift */,
 				4CB65E4929DA6A1200684BD1 /* WhatToBringView.swift */,
 				71B0D5C42B9214B70061033B /* BadgesView.swift */,
@@ -412,6 +414,15 @@
 				71392FAC2BAA40F900496CA5 /* GoogleUserAuthModel.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		74CD87FB2D4DE943000E5DBD /* LandingScreen */ = {
+			isa = PBXGroup;
+			children = (
+				4CB65D9129D016AE00684BD1 /* LandingScreenView.swift */,
+				74CD87FC2D4DE955000E5DBD /* LandingScreenViewModel.swift */,
+			);
+			path = LandingScreen;
 			sourceTree = "<group>";
 		};
 		74FE994D2CC9FEDB00D0C5D0 /* CommunityEvents */ = {
@@ -639,6 +650,7 @@
 				BE9D1DD92A3A419A00072835 /* LoadingView.swift in Sources */,
 				4C0E4FF129DDF726009D33C1 /* DonateView.swift in Sources */,
 				BE9D1DD32A377E9100072835 /* StorgeManager.swift in Sources */,
+				74CD87FD2D4DE955000E5DBD /* LandingScreenViewModel.swift in Sources */,
 				4C7136BB2A01F7E90060EB7D /* ForgotPasswordView.swift in Sources */,
 				4CA8693329E3D05300BB6972 /* InputTile.swift in Sources */,
 				4CB65D9229D016AE00684BD1 /* LandingScreenView.swift in Sources */,

--- a/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
+++ b/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
@@ -40,7 +40,7 @@ struct LandingScreenView: View {
         NavigationStack {
             ZStack {
                 VStack {
-                    if let banner = viewModel.bannerData {
+                    if isBannerVisible, let banner = viewModel.bannerData {
                         BannerView(isBannerVisible: $isBannerVisible, banner: banner)
                     }
                     

--- a/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
+++ b/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
@@ -21,6 +21,7 @@ enum ImageEnum: String {
 }
 
 struct LandingScreenView: View {
+    @StateObject private var viewModel = LandingScreenViewModel()
     
     var links: [LinkData] = [
         LinkData(icon: "startNow", title: "startNow", view: AnyView(StartNowView()), iden: 1),
@@ -39,8 +40,8 @@ struct LandingScreenView: View {
         NavigationStack {
             ZStack {
                 VStack {
-                    if isBannerVisible {
-                        BannerView(isBannerVisible: $isBannerVisible)
+                    if let banner = viewModel.bannerData {
+                        BannerView(isBannerVisible: $isBannerVisible, banner: banner)
                     }
                     
                     ScrollView {
@@ -89,6 +90,8 @@ struct LandingScreenView: View {
                             }
                         }
                     }
+                }.onAppear{
+                    viewModel.fetchBannerData()
                 }
             }
             .padding()
@@ -122,21 +125,22 @@ struct PageControl: View {
 }
 struct BannerView: View {
     @Binding var isBannerVisible: Bool
+    let banner: BannerData
     
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(alignment: .leading, spacing: 8) {
-                Text(NSLocalizedString("bannertitle1", comment: ""))
+                Text(banner.header)
                     .font(.caption)
                     .fontWeight(.bold)
                     .foregroundColor(.blue)
                 
-                Text(NSLocalizedString("bannertitle2", comment: ""))
+                Text(banner.subHeader)
                     .font(.title3)
                     .fontWeight(.bold)
                     .foregroundColor(.black)
                 
-                Text(NSLocalizedString("bannertext", comment: ""))
+                Text(banner.body)
                     .font(.subheadline)
                     .foregroundColor(.black)
                     .lineSpacing(4)

--- a/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
+++ b/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenView.swift
@@ -40,8 +40,8 @@ struct LandingScreenView: View {
         NavigationStack {
             ZStack {
                 VStack {
-                    if isBannerVisible, let banner = viewModel.bannerData {
-                        BannerView(isBannerVisible: $isBannerVisible, banner: banner)
+                    if viewModel.shouldShowBanner, let banner = viewModel.bannerData {
+                        BannerView(viewModel: viewModel, banner: banner)
                     }
                     
                     ScrollView {
@@ -124,7 +124,7 @@ struct PageControl: View {
     }
 }
 struct BannerView: View {
-    @Binding var isBannerVisible: Bool
+    @ObservedObject var viewModel: LandingScreenViewModel
     let banner: BannerData
     
     var body: some View {
@@ -160,7 +160,7 @@ struct BannerView: View {
             // Close button
             Button(action: {
                 withAnimation {
-                    isBannerVisible = false
+                    viewModel.dismissBanner()
                 }
             }) {
                 Image(systemName: "xmark.circle.fill")

--- a/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenViewModel.swift
+++ b/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenViewModel.swift
@@ -12,6 +12,8 @@ import FirebaseFirestoreSwift
 
 class LandingScreenViewModel: ObservableObject {
     @Published var bannerData: BannerData? = nil
+    @Published var isBannerVisible: Bool = true
+    
     private var db = Firestore.firestore()
 
     init() {
@@ -19,7 +21,9 @@ class LandingScreenViewModel: ObservableObject {
     }
 
     func fetchBannerData() {
-        db.collection("page_content").document("banner_data").getDocument { snapshot, error in
+        let documentName = isAppLanguageSpanish() ? "banner_data_es" : "banner_data"
+        
+        db.collection("page_content").document(documentName).getDocument { snapshot, error in
             if let error = error {
                 print("Error fetching banner data: \(error.localizedDescription)")
                 return
@@ -36,6 +40,20 @@ class LandingScreenViewModel: ObservableObject {
                 }
             }
         }
+    }
+    
+    var shouldShowBanner: Bool {
+        guard isBannerVisible, let banner = bannerData else { return false }
+        return !banner.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func dismissBanner() {
+        isBannerVisible = false
+    }
+    
+    func isAppLanguageSpanish() -> Bool {
+        guard let languageCode = Locale.preferredLanguages.first else { return false }
+        return languageCode.starts(with: "es")
     }
 }
 

--- a/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenViewModel.swift
+++ b/StreetCare/StreetCare/Views/Screens/LandingScreen/LandingScreenViewModel.swift
@@ -1,0 +1,53 @@
+//
+//  LandingScreenViewModel.swift
+//  StreetCare
+//
+//  Created by Kevin Phillips on 2/1/25.
+//
+
+import Foundation
+import SwiftUI
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+class LandingScreenViewModel: ObservableObject {
+    @Published var bannerData: BannerData? = nil
+    private var db = Firestore.firestore()
+
+    init() {
+        fetchBannerData()
+    }
+
+    func fetchBannerData() {
+        db.collection("page_content").document("banner_data").getDocument { snapshot, error in
+            if let error = error {
+                print("Error fetching banner data: \(error.localizedDescription)")
+                return
+            }
+            
+            if let snapshot = snapshot, snapshot.exists {
+                do {
+                    let data = try snapshot.data(as: BannerData.self)
+                    DispatchQueue.main.async {
+                        self.bannerData = data
+                    }
+                } catch {
+                    print("Error decoding banner data: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}
+
+struct BannerData: Codable, Identifiable {
+    @DocumentID var id: String?
+    let header: String
+    let subHeader: String
+    let body: String
+
+    enum CodingKeys: String, CodingKey {
+        case header
+        case subHeader = "sub_header"
+        case body
+    }
+}

--- a/StreetCare/StreetCare/en.lproj/Localizable.strings
+++ b/StreetCare/StreetCare/en.lproj/Localizable.strings
@@ -138,9 +138,6 @@
 "cmintrotext10" = "Please click here to donate. If you join our Giving Program, we will send you free gifts!";
 "cmintrowithlink1" = "Click here to find out what chapter membership entails.";
 "cmintrowithlink2" = "If you prefer to sign and send ina copy or save it for later reference, please download the form here.";
-"bannertitle1" = "COMING SOON";
-"bannertitle2" = "Get Verified!";
-"bannertext" = "Profile verification will allow anyone who is verified to post upcoming events and document their interactions with homeless individuals.";
 //"welcome" = "Welcome to\nStreet Care";
 //"loginButtonTitle" = "Login";
 //"signUpButtonTitle" = "Sign Up";

--- a/StreetCare/StreetCare/es.lproj/Localizable.strings
+++ b/StreetCare/StreetCare/es.lproj/Localizable.strings
@@ -112,9 +112,6 @@
 "cmintrotext10" = "Haz clic aquí para donar. Si te unes a nuestro Programa de donaciones, ¡te enviaremos obsequios gratis!";
 "cmintrowithlink1" = "Haga clic aquí para saber qué implica ser miembro de un capítulo.";
 "cmintrowithlink2" = "Si prefiere firmar y enviar una copia o guardarla para consultarla más adelante, descargue el formulario aquí.";
-"bannertitle1" = "PRÓXIMAMENTE";
-"bannertitle2" = "Obtener verificado!";
-"bannertext" = "La verificación de perfil permitirá a cualquier persona verificada publicar próximos eventos y documentar sus interacciones con personas sin hogar.";
 //"helloWorld" = "¡Hola Mundo!";
 //"welcome" = "Bienvenido a\nStreet Care";
 //"loginButtonTitle" = "Acceso";


### PR DESCRIPTION
Fetching content for banner view from Firebase to enable dynamic server driven content. Added a check for spanish localization and check for null body description to control overall banner visibility. Connected live data and viewModel to fragment

Spanish
<img width="412" alt="image" src="https://github.com/user-attachments/assets/b8515904-e752-4cb4-a3f7-d713e97a73cb" />

English
<img width="428" alt="image" src="https://github.com/user-attachments/assets/68ba8e32-4f48-4b9f-aef8-fe9671c95345" />
