### PR TITLE
Public interaction popup view

### DIFF
--- a/StreetCare/StreetCare.xcodeproj/project.pbxproj
+++ b/StreetCare/StreetCare.xcodeproj/project.pbxproj
@@ -89,13 +89,14 @@
 		71FA51052BD1909500D0DA6C /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FA51042BD1909500D0DA6C /* SplashView.swift */; };
 		7453ABBB2D66D3BC00469896 /* AppDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7453ABBA2D66D3BC00469896 /* AppDescriptionView.swift */; };
 		74CD87FD2D4DE955000E5DBD /* LandingScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CD87FC2D4DE955000E5DBD /* LandingScreenViewModel.swift */; };
-		74DC15772D66BB6500EF58AE /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 74DC15762D66BB6500EF58AE /* Secrets.plist */; };
 		74DC15792D66D05000EF58AE /* ImageSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DC15782D66D05000EF58AE /* ImageSliderView.swift */; };
 		74FDD8282D64917100E23293 /* GoogleMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FDD8212D64907C00E23293 /* GoogleMapView.swift */; };
 		74FDD8292D64917100E23293 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FDD8222D64907C00E23293 /* MapViewModel.swift */; };
 		74FE994C2CC9F23F00D0C5D0 /* EventEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE994B2CC9F23F00D0C5D0 /* EventEnums.swift */; };
 		74FE994F2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE994E2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift */; };
 		74FE99512CC9FFAB00D0C5D0 /* EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FE99502CC9FFAB00D0C5D0 /* EventCardView.swift */; };
+		7A03D72D2DE102290027D5E7 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7A03D72C2DE102290027D5E7 /* Secrets.plist */; };
+		7A03D7432DE11E300027D5E7 /* PublicInteractionPopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A03D7422DE11E300027D5E7 /* PublicInteractionPopupView.swift */; };
 		A459D493C5D37756A585D3EA /* Pods_StreetCare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B3FB734328ABC03284A67BF /* Pods_StreetCare.framework */; };
 		BE9D1DCE2A37626C00072835 /* ImagePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9D1DCD2A37626C00072835 /* ImagePickerView.swift */; };
 		BE9D1DD12A376B3800072835 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = BE9D1DD02A376B3800072835 /* FirebaseStorage */; };
@@ -198,13 +199,14 @@
 		71FA51042BD1909500D0DA6C /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		7453ABBA2D66D3BC00469896 /* AppDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDescriptionView.swift; sourceTree = "<group>"; };
 		74CD87FC2D4DE955000E5DBD /* LandingScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandingScreenViewModel.swift; sourceTree = "<group>"; };
-		74DC15762D66BB6500EF58AE /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Secrets.plist; path = StreetCare/Secrets.plist; sourceTree = "<group>"; };
 		74DC15782D66D05000EF58AE /* ImageSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSliderView.swift; sourceTree = "<group>"; };
 		74FDD8212D64907C00E23293 /* GoogleMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleMapView.swift; sourceTree = "<group>"; };
 		74FDD8222D64907C00E23293 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		74FE994B2CC9F23F00D0C5D0 /* EventEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventEnums.swift; sourceTree = "<group>"; };
 		74FE994E2CC9FF5F00D0C5D0 /* SearchCommunityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchCommunityModel.swift; sourceTree = "<group>"; };
 		74FE99502CC9FFAB00D0C5D0 /* EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventCardView.swift; sourceTree = "<group>"; };
+		7A03D72C2DE102290027D5E7 /* Secrets.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
+		7A03D7422DE11E300027D5E7 /* PublicInteractionPopupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicInteractionPopupView.swift; sourceTree = "<group>"; };
 		BE9D1DCD2A37626C00072835 /* ImagePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePickerView.swift; sourceTree = "<group>"; };
 		BE9D1DD22A377E9100072835 /* StorgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorgeManager.swift; sourceTree = "<group>"; };
 		BE9D1DD42A37819E00072835 /* AvatarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarView.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				4CA8693429E3FA8600BB6972 /* VisitLogEntry.swift */,
 				4CB65D9E29D0DEAE00684BD1 /* VisitLogView.swift */,
 				4C17ED502A00A3610013EF52 /* VisitLogUnauthorized.swift */,
+				7A03D7422DE11E300027D5E7 /* PublicInteractionPopupView.swift */,
 			);
 			path = "Visit Log";
 			sourceTree = "<group>";
@@ -297,7 +300,6 @@
 				BE9D1DCF2A376B3800072835 /* Frameworks */,
 				D864E90A530FD26B201E4F4F /* Pods */,
 				4CB65D8D29D016AE00684BD1 /* Products */,
-				74DC15762D66BB6500EF58AE /* Secrets.plist */,
 				4CB65D8E29D016AE00684BD1 /* StreetCare */,
 			);
 			sourceTree = "<group>";
@@ -325,6 +327,7 @@
 				4CB65E4F29DA6FE900684BD1 /* LinkData.swift */,
 				1F5C885F2C1CDF2D00684361 /* Common.swift */,
 				74FE994B2CC9F23F00D0C5D0 /* EventEnums.swift */,
+				7A03D72C2DE102290027D5E7 /* Secrets.plist */,
 			);
 			path = StreetCare;
 			sourceTree = "<group>";
@@ -564,7 +567,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				74DC15772D66BB6500EF58AE /* Secrets.plist in Resources */,
+				7A03D72D2DE102290027D5E7 /* Secrets.plist in Resources */,
 				4C82441429EC99A8003D1575 /* Localizable.strings in Resources */,
 				4CB65D9729D016B000684BD1 /* Preview Assets.xcassets in Resources */,
 				4CB65D9429D016B000684BD1 /* Assets.xcassets in Resources */,
@@ -646,6 +649,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7A03D7432DE11E300027D5E7 /* PublicInteractionPopupView.swift in Sources */,
 				74FDD8282D64917100E23293 /* GoogleMapView.swift in Sources */,
 				74FDD8292D64917100E23293 /* MapViewModel.swift in Sources */,
 				4CB7D8CE29F8DCBC0002495E /* TimeDurationPicker.swift in Sources */,

--- a/StreetCare/StreetCare/Models/VisitLog.swift
+++ b/StreetCare/StreetCare/Models/VisitLog.swift
@@ -63,6 +63,7 @@ class VisitLog: ObservableObject, Identifiable {
     @Published var followUpWhenVisit = Date()
     @Published var itemQty = 0
     @Published var isFlagged = false
+    @Published var peopleHelpedDescription = ""
 
     var whatGiven: [String] {
         var given = [String]()

--- a/StreetCare/StreetCare/Models/VisitLog.swift
+++ b/StreetCare/StreetCare/Models/VisitLog.swift
@@ -62,6 +62,7 @@ class VisitLog: ObservableObject, Identifiable {
     @Published var peopleNeedFurtherHelpLocation = ""
     @Published var followUpWhenVisit = Date()
     @Published var itemQty = 0
+    @Published var isFlagged = false
 
     var whatGiven: [String] {
         var given = [String]()

--- a/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
+++ b/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
@@ -397,6 +397,10 @@ class VisitLogDataAdapter {
                     if let itemQty = document["itemQty"] as? Int {
                         log.itemQty = itemQty
                     }
+                    
+                    if let isFlagged = document["isFlagged"] as? Bool {
+                        log.isFlagged = isFlagged
+                    }
 
                     self.visitLogs.append(log)
                 }

--- a/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
+++ b/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
@@ -302,6 +302,10 @@ class VisitLogDataAdapter {
                     if let peopleHelped = document["peopleHelped"] as? Int {
                         log.peopleHelped = peopleHelped
                     }
+                    
+                    if let peopleHelpedDescription = document["peopleHelpedDescription"] as? String {
+                        log.peopleHelpedDescription = peopleHelpedDescription
+                    }
 
                     if let foodAndDrinks = document["foodAndDrinks"] as? Bool {
                         log.foodAndDrinks = foodAndDrinks

--- a/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
+++ b/StreetCare/StreetCare/Models/VisitLogDataAdapter.swift
@@ -69,6 +69,7 @@ class VisitLogDataAdapter {
         userData["furtherOther"] = visitLog.furtherOther
         userData["furtherOtherNotes"] = visitLog.furtherOtherNotes
         userData["followUpWhenVisit"] = visitLog.followUpWhenVisit
+        userData["itemQty"] = visitLog.itemQty
 
 
         if visitLog.location.latitude != 0 {
@@ -88,6 +89,7 @@ class VisitLogDataAdapter {
             }
         }
     }
+
     func addVisitLog_Community(_ visitLog: VisitLog) {
     
         guard let user = Auth.auth().currentUser else {
@@ -390,6 +392,10 @@ class VisitLogDataAdapter {
 
                     if let furtherOtherNotes = document["furtherOtherNotes"] as? String {
                         log.furtherOtherNotes = furtherOtherNotes
+                    }
+                    
+                    if let itemQty = document["itemQty"] as? Int {
+                        log.itemQty = itemQty
                     }
 
                     self.visitLogs.append(log)

--- a/StreetCare/StreetCare/Views/Screens/EventPopupView.swift
+++ b/StreetCare/StreetCare/Views/Screens/EventPopupView.swift
@@ -306,13 +306,14 @@ func formattedTime(_ date: Date?) -> String {
 
 struct BottomSheetModifier<SheetContent: View>: ViewModifier {
     @Binding var isPresented: Bool
+    let heightRatio: CGFloat
     let sheetContent: () -> SheetContent
 
     func body(content: Content) -> some View {
         ZStack {
             content
             if isPresented {
-                BottomSheetView(isPresented: $isPresented, content: sheetContent)
+                BottomSheetView(isPresented: $isPresented, heightRatio: heightRatio, content: sheetContent)
                     .edgesIgnoringSafeArea(.all)
             }
         }
@@ -320,17 +321,19 @@ struct BottomSheetModifier<SheetContent: View>: ViewModifier {
 }
 
 extension View {
-    func bottomSheet<SheetContent: View>(isPresented: Binding<Bool>, @ViewBuilder content: @escaping () -> SheetContent) -> some View {
-        self.modifier(BottomSheetModifier(isPresented: isPresented, sheetContent: content))
+    func bottomSheet<SheetContent: View>(isPresented: Binding<Bool>, @ViewBuilder content: @escaping () -> SheetContent,  heightRatio: CGFloat = 0.5) -> some View {
+        self.modifier(BottomSheetModifier(isPresented: isPresented, heightRatio: heightRatio, sheetContent: content))
     }
 }
 
 struct BottomSheetView<Content: View>: View {
     @Binding var isPresented: Bool
     let content: Content
+    var heightRatio: CGFloat = 0.5 // ✅ default 50%
 
-    init(isPresented: Binding<Bool>, @ViewBuilder content: () -> Content) {
+    init(isPresented: Binding<Bool>, heightRatio: CGFloat = 0.5, @ViewBuilder content: () -> Content) {
         self._isPresented = isPresented
+        self.heightRatio = heightRatio
         self.content = content()
     }
 
@@ -341,7 +344,7 @@ struct BottomSheetView<Content: View>: View {
                 VStack {
                     self.content
                 }
-                .frame(width: geometry.size.width, height: UIScreen.main.bounds.height / 2) // Adjust height as needed
+                .frame(width: geometry.size.width, height: geometry.size.height * heightRatio) // Adjust height as needed
                 .background(Color.white)
                 .cornerRadius(20)
                 .shadow(radius: 10)
@@ -358,3 +361,41 @@ struct BottomSheetView<Content: View>: View {
         }
     }
 }
+
+
+
+//struct BottomSheetView<Content: View>: View {
+//    @Binding var isPresented: Bool
+//    let content: Content
+//    var heightRatio: CGFloat = 0.5
+//
+//    init(isPresented: Binding<Bool>, heightRatio: CGFloat = 0.5, @ViewBuilder content: () -> Content) {
+//        self._isPresented = isPresented
+//        self.heightRatio = heightRatio
+//        self.content = content()
+//    }
+//
+//    var body: some View {
+//        GeometryReader { geometry in
+//            ZStack(alignment: .bottom) {
+//                // Dimmed background
+//                if isPresented {
+//                    Color.black.opacity(0.3)
+//                        .edgesIgnoringSafeArea(.all)
+//                        .onTapGesture {
+//                            self.isPresented = false
+//                        }
+//                }
+//
+//                // Bottom Sheet
+//                content
+//                    .frame(width: geometry.size.width, height: geometry.size.height * heightRatio)
+//                    .background(Color.white)
+//                    .cornerRadius(20)
+//                    .shadow(radius: 10)
+//                    .transition(.move(edge: .bottom))
+//                    .animation(.easeInOut, value: isPresented)
+//            }
+//        }
+//    }
+//}

--- a/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
+++ b/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
@@ -1,0 +1,293 @@
+//
+//  PublicInteractionPopupView.swift
+//  StreetCare
+//
+//  Created by Nilesh Bhoi on 5/23/25.
+//
+
+import SwiftUI
+
+struct PublicInteractionPopupView: View {
+    var name: String
+    var profileImageURL: URL?
+    var date: Date
+    //    var city: String
+    //    var state: String
+    var address: String
+    var interactionDescription: String
+
+    var peopleHelped: Int
+    var joinedPeople: Int
+    var itemsDonated: Int
+
+    var helpType: [String]
+
+    var onCancel: () -> Void
+    var delegate : EventPopupViewDelegate?
+    
+    @State private var isFlagged = false
+    @State private var isVerified = true
+
+
+//    var body: some View {
+//        VStack(alignment: .leading, spacing: 14) {
+//            // Top row: avatar, name, spacer, icons
+//            HStack {
+//                profileImage
+//                    .resizable()
+//                    .frame(width: 40, height: 40)
+//                    .clipShape(Circle())
+//                
+//                Text(name)
+//                    .font(.system(size: 15, weight: .semibold))
+//                
+//                Spacer()
+//                
+//                Image(systemName: "flag.fill")
+//                    .foregroundColor(.gray)
+//                
+//                Image(systemName: "checkmark.circle.fill")
+//                    .foregroundColor(.yellow)
+//            }
+//            
+//            // Location & date
+//            HStack(spacing: 8) {
+//                Image(systemName: "mappin.and.ellipse")
+//                    .foregroundColor(.gray)
+//                //                    Text("\(city), \(state)")
+//                //                        .font(.system(size: 13))
+//                Text("\(address)")
+//                    .font(.system(size: 13))
+//            }
+//            
+//            HStack(spacing: 8) {
+//                Image(systemName: "clock")
+//                    .foregroundColor(.gray)
+//                //                    Text(date.formatted(date: .long, time: .shortened))
+//                //                        .font(.system(size: 13))
+//                Text(formattedDateTime(date))
+//                    .font(.system(size: 13))
+//            }
+//            
+//            // Description
+//            VStack(alignment: .leading, spacing: 4) {
+//                Text("Interaction Description")
+//                    .font(.system(size: 14, weight: .semibold))
+//                Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nibh ex, rhoncus ut tincidunt nec, pretium sit amet diam.")
+////                Text(interactionDescription)
+//                    .font(.system(size: 13))
+//                    .fixedSize(horizontal: false, vertical: true)
+//            }
+//            
+//            // Stats
+//            VStack(alignment: .leading, spacing: 12) {
+//                PublicInfoRow(title: "People Helped", value: "\(peopleHelped)", iconName: "Tab-Profile", iconColor: .yellow)
+//                
+//                PublicInfoRow(title: "People Who Joined", value: "\(joinedPeople)", iconName: "HelpingHands", iconColor: .yellow)
+//                
+//                PublicInfoRow(title: "Items Donated", value: "\(itemsDonated)", iconName: "Clothes", iconColor: .yellow)
+//                //                    PublicInfoRow(title: "Type of Help Offered", value: helpType.joined(separator: ", "))
+//                PublicInfoRow(
+//                    title: "Type of Help Offered",
+//                    value: helpType.isEmpty ? "N/A" : helpType.joined(separator: ", ")
+//                )
+//                
+//            }
+//            
+//            
+//            // Button
+//            NavLinkButton(title: "Close", width: UIScreen.main.bounds.width - 33, secondaryButton: true)
+//                .fontWeight(.semibold)
+//                .frame(maxWidth: .infinity, alignment: .center)
+//                .onTapGesture {
+//                    delegate?.close()
+//                }
+//        }
+//        //            .padding()
+//        //            .background(Color.white)
+//        .cornerRadius(20)
+//        //            .shadow(radius: 8)
+//        //            .padding(.horizontal)
+//        //            .frame(height: UIScreen.main.bounds.height * 0.6) // Or 0.7 for taller sheet
+//        .toolbar(.hidden, for: .tabBar) // 👈 this line hides the bottom tab bar
+//        
+//        
+//    }
+    
+    var body: some View {
+            VStack(alignment: .leading, spacing: 14) {
+                // Top row
+                HStack {
+//                    profileImage
+//                        .resizable()
+//                        .frame(width: 40, height: 40)
+//                        .clipShape(Circle())
+                    
+                    if let url = profileImageURL {
+                        AsyncImage(url: url) { image in
+                            image
+                                .resizable()
+                                .frame(width: 40, height: 40)
+                                .clipShape(Circle())
+                        } placeholder: {
+                            Image(systemName: "person.crop.circle")
+                                .resizable()
+                                .frame(width: 40, height: 40)
+                                .clipShape(Circle())
+                                .opacity(0.5)
+                        }
+                    } else {
+                        Image(systemName: "person.crop.circle")
+                            .resizable()
+                            .frame(width: 40, height: 40)
+                            .clipShape(Circle())
+                    }
+
+                    Text(name)
+                        .font(.system(size: 15, weight: .semibold))
+
+                    Spacer()
+
+                    // Flag toggle
+                    Image(systemName: "flag.fill")
+                        .foregroundColor(isFlagged ? .red : .gray)
+                        .onTapGesture {
+                            isFlagged.toggle()
+                        }
+
+                    // Verified toggle (for demo)
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(isVerified ? .yellow : .gray)
+                }
+
+                // Location & date
+                HStack(spacing: 8) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .foregroundColor(.gray)
+                    Text(address)
+                        .font(.system(size: 13))
+                }
+
+                HStack(spacing: 8) {
+                    Image(systemName: "clock")
+                        .foregroundColor(.gray)
+                    Text(formattedDateTime(date))
+                        .font(.system(size: 13))
+                }
+
+                // Description
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Interaction Description")
+                        .font(.system(size: 14, weight: .semibold))
+                    Text(interactionDescription)
+                        .font(.system(size: 13))
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                // Stats
+                VStack(alignment: .leading, spacing: 12) {
+                    PublicInfoRow(title: "People Helped", value: "\(peopleHelped)", iconName: "Tab-Profile", iconColor: .yellow)
+                    PublicInfoRow(title: "People Who Joined", value: "\(joinedPeople)", iconName: "HelpingHands", iconColor: .yellow)
+                    PublicInfoRow(title: "Items Donated", value: "\(itemsDonated)", iconName: "Clothes", iconColor: .yellow)
+                    PublicInfoRow(title: "Type of Help Offered", value: helpType.isEmpty ? "N/A" : helpType.joined(separator: ", "))
+                }
+
+                // Close Button
+                NavLinkButton(title: "Close", width: UIScreen.main.bounds.width - 30, secondaryButton: true)
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .onTapGesture {
+                        delegate?.close()
+                        onCancel()
+                    }
+            }
+            .cornerRadius(20)
+            .toolbar(.hidden, for: .tabBar)
+        }
+
+}
+
+
+//struct InfoRowWithIcon: View {
+//    var icon: String
+//    var label: String
+//    var value: String
+//    
+//    var body: some View {
+//        HStack(alignment: .top, spacing: 8) {
+//            Image(systemName: icon)
+//                .foregroundColor(.gray)
+//                .frame(width: 10)
+//            VStack(alignment: .leading, spacing: 2) {
+//                Text(label)
+//                    .font(.caption)
+//                    .foregroundColor(.secondary)
+//                Text(value)
+//                    .font(.body)
+//            }
+//        }
+//    }
+//}
+
+func formattedDateTime(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "MMMM d, yyyy | h:mma"
+    formatter.amSymbol = "AM"
+    formatter.pmSymbol = "PM"
+    return formatter.string(from: date)
+}
+
+struct InfoValueRow: View {
+    var value: String
+    var iconName: String?
+    var iconColor: Color = .yellow
+    
+    var body: some View {
+        HStack(spacing: 8) {
+            if let icon = iconName, !icon.isEmpty {
+                Image(icon)
+                    .resizable()
+                    .interpolation(.none)
+                    .frame(width: 20, height: 20)
+                    .foregroundColor(iconColor)
+            }
+            Text(value)
+                .font(.system(size: 13))
+        }
+    }
+}
+
+struct PublicInfoRow: View {
+    var title: String
+    var value: String
+    var iconName: String? = nil
+    var iconColor: Color = .yellow
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+            
+            InfoValueRow(value: value, iconName: iconName, iconColor: iconColor)
+        }
+    }
+}
+
+
+#Preview {
+    PublicInteractionPopupView(
+        name: "John Doe",
+//        profileImageURL: "",
+        date: Date(),
+        address: "123 Main St, Springfield, IL",
+        interactionDescription: "Distributed food and clothes to 5 individuals at the park.",
+        peopleHelped: 5,
+        joinedPeople:  2,
+        itemsDonated: 10,
+        helpType: ["Food", "Clothes", "Water"],
+        onCancel: {},
+        delegate: nil
+    )
+    .padding()
+//    .previewLayout(.sizeThatFits)
+}

--- a/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
+++ b/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
@@ -6,228 +6,212 @@
 //
 
 import SwiftUI
+import FirebaseFirestore
+import FirebaseAuth
+
 
 struct PublicInteractionPopupView: View {
-    var name: String
-    var profileImageURL: URL?
-    var date: Date
-    //    var city: String
-    //    var state: String
-    var address: String
-    var interactionDescription: String
-
-    var peopleHelped: Int
-    var joinedPeople: Int
-    var itemsDonated: Int
-
-    var helpType: [String]
-
+    @ObservedObject var visit: VisitLog
+    var user: User?
+    var userType: String
     var onCancel: () -> Void
     var delegate : EventPopupViewDelegate?
     
-    @State private var isFlagged = false
-    @State private var isVerified = true
-
-
-//    var body: some View {
-//        VStack(alignment: .leading, spacing: 14) {
-//            // Top row: avatar, name, spacer, icons
-//            HStack {
-//                profileImage
-//                    .resizable()
-//                    .frame(width: 40, height: 40)
-//                    .clipShape(Circle())
-//                
-//                Text(name)
-//                    .font(.system(size: 15, weight: .semibold))
-//                
-//                Spacer()
-//                
-//                Image(systemName: "flag.fill")
-//                    .foregroundColor(.gray)
-//                
-//                Image(systemName: "checkmark.circle.fill")
-//                    .foregroundColor(.yellow)
-//            }
-//            
-//            // Location & date
-//            HStack(spacing: 8) {
-//                Image(systemName: "mappin.and.ellipse")
-//                    .foregroundColor(.gray)
-//                //                    Text("\(city), \(state)")
-//                //                        .font(.system(size: 13))
-//                Text("\(address)")
-//                    .font(.system(size: 13))
-//            }
-//            
-//            HStack(spacing: 8) {
-//                Image(systemName: "clock")
-//                    .foregroundColor(.gray)
-//                //                    Text(date.formatted(date: .long, time: .shortened))
-//                //                        .font(.system(size: 13))
-//                Text(formattedDateTime(date))
-//                    .font(.system(size: 13))
-//            }
-//            
-//            // Description
-//            VStack(alignment: .leading, spacing: 4) {
-//                Text("Interaction Description")
-//                    .font(.system(size: 14, weight: .semibold))
-//                Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nibh ex, rhoncus ut tincidunt nec, pretium sit amet diam.")
-////                Text(interactionDescription)
-//                    .font(.system(size: 13))
-//                    .fixedSize(horizontal: false, vertical: true)
-//            }
-//            
-//            // Stats
-//            VStack(alignment: .leading, spacing: 12) {
-//                PublicInfoRow(title: "People Helped", value: "\(peopleHelped)", iconName: "Tab-Profile", iconColor: .yellow)
-//                
-//                PublicInfoRow(title: "People Who Joined", value: "\(joinedPeople)", iconName: "HelpingHands", iconColor: .yellow)
-//                
-//                PublicInfoRow(title: "Items Donated", value: "\(itemsDonated)", iconName: "Clothes", iconColor: .yellow)
-//                //                    PublicInfoRow(title: "Type of Help Offered", value: helpType.joined(separator: ", "))
-//                PublicInfoRow(
-//                    title: "Type of Help Offered",
-//                    value: helpType.isEmpty ? "N/A" : helpType.joined(separator: ", ")
-//                )
-//                
-//            }
-//            
-//            
-//            // Button
-//            NavLinkButton(title: "Close", width: UIScreen.main.bounds.width - 33, secondaryButton: true)
-//                .fontWeight(.semibold)
-//                .frame(maxWidth: .infinity, alignment: .center)
-//                .onTapGesture {
-//                    delegate?.close()
-//                }
-//        }
-//        //            .padding()
-//        //            .background(Color.white)
-//        .cornerRadius(20)
-//        //            .shadow(radius: 8)
-//        //            .padding(.horizontal)
-//        //            .frame(height: UIScreen.main.bounds.height * 0.6) // Or 0.7 for taller sheet
-//        .toolbar(.hidden, for: .tabBar) // 👈 this line hides the bottom tab bar
-//        
-//        
-//    }
+    @Binding var refresh: Bool
+    @State private var showCustomAlert = false
+    @State private var alertMessage = ""
     
     var body: some View {
-            VStack(alignment: .leading, spacing: 14) {
-                // Top row
-                HStack {
-//                    profileImage
-//                        .resizable()
-//                        .frame(width: 40, height: 40)
-//                        .clipShape(Circle())
-                    
-                    if let url = profileImageURL {
-                        AsyncImage(url: url) { image in
-                            image
-                                .resizable()
-                                .frame(width: 40, height: 40)
-                                .clipShape(Circle())
-                        } placeholder: {
-                            Image(systemName: "person.crop.circle")
-                                .resizable()
-                                .frame(width: 40, height: 40)
-                                .clipShape(Circle())
-                                .opacity(0.5)
-                        }
-                    } else {
+        VStack(alignment: .leading, spacing: 14) {
+            // Top row
+            HStack {
+                if let url = user?.photoURL {
+                    AsyncImage(url: url) { image in
+                        image
+                            .resizable()
+                            .frame(width: 40, height: 40)
+                            .clipShape(Circle())
+                    } placeholder: {
                         Image(systemName: "person.crop.circle")
                             .resizable()
                             .frame(width: 40, height: 40)
                             .clipShape(Circle())
+                            .opacity(0.5)
                     }
-
-                    Text(name)
-                        .font(.system(size: 15, weight: .semibold))
-
-                    Spacer()
-
-                    // Flag toggle
-                    Image(systemName: "flag.fill")
-                        .foregroundColor(isFlagged ? .red : .gray)
-                        .onTapGesture {
-                            isFlagged.toggle()
-                        }
-
-                    // Verified toggle (for demo)
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(isVerified ? .yellow : .gray)
+                } else {
+                    Image(systemName: "person.crop.circle")
+                        .resizable()
+                        .frame(width: 40, height: 40)
+                        .clipShape(Circle())
                 }
-
-                // Location & date
-                HStack(spacing: 8) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .foregroundColor(.gray)
-                    Text(address)
-                        .font(.system(size: 13))
-                }
-
-                HStack(spacing: 8) {
-                    Image(systemName: "clock")
-                        .foregroundColor(.gray)
-                    Text(formattedDateTime(date))
-                        .font(.system(size: 13))
-                }
-
-                // Description
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Interaction Description")
-                        .font(.system(size: 14, weight: .semibold))
-                    Text(interactionDescription)
-                        .font(.system(size: 13))
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                // Stats
-                VStack(alignment: .leading, spacing: 12) {
-                    PublicInfoRow(title: "People Helped", value: "\(peopleHelped)", iconName: "Tab-Profile", iconColor: .yellow)
-                    PublicInfoRow(title: "People Who Joined", value: "\(joinedPeople)", iconName: "HelpingHands", iconColor: .yellow)
-                    PublicInfoRow(title: "Items Donated", value: "\(itemsDonated)", iconName: "Clothes", iconColor: .yellow)
-                    PublicInfoRow(title: "Type of Help Offered", value: helpType.isEmpty ? "N/A" : helpType.joined(separator: ", "))
-                }
-
-                // Close Button
-                NavLinkButton(title: "Close", width: UIScreen.main.bounds.width - 30, secondaryButton: true)
-                    .fontWeight(.semibold)
-                    .frame(maxWidth: .infinity, alignment: .center)
+                
+                Text(user?.displayName ?? "Firstname Lastname")
+                    .font(.system(size: 15, weight: .semibold))
+                
+                Spacer()
+                
+                // Flag toggle
+                Image(systemName: "flag.fill")
+                    .foregroundColor(visit.isFlagged ? .red : .gray)
                     .onTapGesture {
-                        delegate?.close()
-                        onCancel()
+                        Task {
+                            let db = Firestore.firestore()
+//                            print(visit.id)
+                            let ref = db.collection("VisitLogBook").document(visit.id) // have to check for the correct document
+//                            print(ref.documentID)
+                            let updates: [String: Any] = [
+                                "isFlagged": false,
+                                "flaggedByUser": NSNull()
+                            ]
+                            if visit.isFlagged {
+                                // UNFLAGGING
+                                // Allow to unflag if flagged by same user (==currentUser)
+//                                print("Checking if user \(user?.uid ?? "") is flagged by user \(visit.flaggedByUser ?? "")")
+                                if visit.flaggedByUser == user?.uid || userType == "Street Care Hub Leader" {
+                                    // Allow unflagging
+                                    do {
+                                        try await ref.updateData(updates)
+                                        
+                                        visit.isFlagged = false
+                                        visit.flaggedByUser = ""
+                                        refresh.toggle()
+//                                        print("Successfully unflagged event by user \(user?.uid ?? "")")
+                                    } catch {
+//                                        print("Error updating flag status: \(error)")
+                                    }
+
+                                } else {
+                                    // Not allowed, show alert
+                                    await MainActor.run {
+                                        alertMessage = "Only the user who flagged this event or a Street Care Hub Leader can unflag it."
+                                        showCustomAlert = true
+                                    }
+                                }
+                            } else {
+                                // FLAGGING
+                                let updates: [String: Any] = [
+                                    "isFlagged": true,
+                                    "flaggedByUser": user?.uid
+                                ]
+
+                                do {
+                                    try await ref.updateData(updates)
+
+                                    visit.isFlagged = true
+                                    visit.flaggedByUser = user?.uid ?? ""
+                                    refresh.toggle()
+//                                    print("Successfully flagged event by user \(user?.uid ?? "")")
+                                } catch {
+//                                    print("Error updating flag status: \(error)")
+                                }
+                            }
+                            
+                        }
                     }
+                
+                // checkmark
+                UserRoleBadge(userType: userType)
             }
-            .cornerRadius(20)
-            .toolbar(.hidden, for: .tabBar)
+            
+            // Location & date
+            HStack(spacing: 8) {
+                Image(systemName: "mappin.and.ellipse")
+                    .foregroundColor(.gray)
+                Text(visit.whereVisit)
+                    .font(.system(size: 13))
+            }
+            
+            HStack(spacing: 8) {
+                Image(systemName: "clock")
+                    .foregroundColor(.gray)
+                Text(formattedDateTime(visit.whenVisit))
+                    .font(.system(size: 13))
+            }
+            
+            // Description
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Interaction Description")
+                    .font(.system(size: 14, weight: .semibold))
+                Text(visit.otherNotes)
+                    .font(.system(size: 13))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            
+            // Stats
+            VStack(alignment: .leading, spacing: 12) {
+                PublicInfoRow(title: "People Helped", value: "\(visit.peopleHelped)", iconName: "Tab-Profile", iconColor: .yellow)
+                PublicInfoRow(title: "People Who Joined", value: "\(visit.numberOfHelpers)", iconName: "HelpingHands", iconColor: .yellow)
+                PublicInfoRow(title: "Items Donated", value: "\(visit.itemQty)", iconName: "Clothes", iconColor: .yellow)
+                PublicInfoRow(title: "Type of Help Offered", value: visit.whatGiven.isEmpty ? "N/A" : visit.whatGiven.joined(separator: ", "))
+            }
+            
+            // Close Button
+            NavLinkButton(title: "Close", width: UIScreen.main.bounds.width - 30, secondaryButton: true)
+                .fontWeight(.semibold)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .onTapGesture {
+                    delegate?.close()
+                    onCancel()
+                }
         }
+        .cornerRadius(20)
+        .toolbar(.hidden, for: .tabBar)
+        .overlay(
+            Group {
+                if showCustomAlert {
+                    ZStack {
+                        // Softened dimmed background with subtle blur and corners
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.clear)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .edgesIgnoringSafeArea(.all)
 
+                        // Alert Box
+                        VStack(spacing: 0) {
+                            VStack(spacing: 16) {
+                                Text("Unflag Error")
+                                    .font(.headline)
+                                    .foregroundColor(.black)
+
+                                Text(alertMessage)
+                                    .font(.subheadline)
+                                    .foregroundColor(.black)
+                                    .multilineTextAlignment(.center)
+                                    .fixedSize(horizontal: false, vertical: true) // ✅ Enables line wrapping
+                                    .frame(maxWidth: .infinity)
+                            }
+                            .padding()
+
+                            Divider()
+
+                            Button(action: {
+                                withAnimation {
+                                    showCustomAlert = false
+                                }
+                            }) {
+                                Text("OK")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 12)
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                        .frame(width: 300)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14)
+                                .fill(Color.white)
+                                .shadow(radius: 20)
+                        )
+                        .transition(.scale)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+
+        )
+    }
+    
+    
 }
-
-
-//struct InfoRowWithIcon: View {
-//    var icon: String
-//    var label: String
-//    var value: String
-//    
-//    var body: some View {
-//        HStack(alignment: .top, spacing: 8) {
-//            Image(systemName: icon)
-//                .foregroundColor(.gray)
-//                .frame(width: 10)
-//            VStack(alignment: .leading, spacing: 2) {
-//                Text(label)
-//                    .font(.caption)
-//                    .foregroundColor(.secondary)
-//                Text(value)
-//                    .font(.body)
-//            }
-//        }
-//    }
-//}
 
 func formattedDateTime(_ date: Date) -> String {
     let formatter = DateFormatter()
@@ -273,21 +257,27 @@ struct PublicInfoRow: View {
     }
 }
 
-
-#Preview {
-    PublicInteractionPopupView(
-        name: "John Doe",
-//        profileImageURL: "",
-        date: Date(),
-        address: "123 Main St, Springfield, IL",
-        interactionDescription: "Distributed food and clothes to 5 individuals at the park.",
-        peopleHelped: 5,
-        joinedPeople:  2,
-        itemsDonated: 10,
-        helpType: ["Food", "Clothes", "Water"],
-        onCancel: {},
-        delegate: nil
-    )
-    .padding()
-//    .previewLayout(.sizeThatFits)
+struct UserRoleBadge: View {
+    var userType: String
+    
+    func userTypeBadge(for userType: String) -> (Color, String) {
+        switch userType {
+        case "Chapter Leader":
+            return (.green, "Chapter Leader")
+        case "Street Care Hub Leader":
+            return (Color.blue.opacity(0.7), "Street Care Hub Leader")
+        case "Chapter Member":
+            return (.purple, "Chapter Member")
+        default:
+            return (.yellow, "Chapter Member")
+        }
+    }
+    
+    var body: some View {
+        let (badgeColor, badgeText) = userTypeBadge(for: userType)
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(badgeColor)
+        }
+    }
 }

--- a/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
+++ b/StreetCare/StreetCare/Views/Screens/Visit Log/PublicInteractionPopupView.swift
@@ -57,7 +57,7 @@ struct PublicInteractionPopupView: View {
                         Task {
                             let db = Firestore.firestore()
 //                            print(visit.id)
-                            let ref = db.collection("VisitLogBook").document(visit.id) // have to check for the correct document
+                            let ref = db.collection("visitLogWebProd").document(visit.id)
 //                            print(ref.documentID)
                             let updates: [String: Any] = [
                                 "isFlagged": false,
@@ -132,7 +132,7 @@ struct PublicInteractionPopupView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Interaction Description")
                     .font(.system(size: 14, weight: .semibold))
-                Text(visit.otherNotes)
+                Text(visit.peopleHelpedDescription)
                     .font(.system(size: 13))
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/StreetCare/StreetCare/Views/Screens/Visit Log/VisitImpactView.swift
+++ b/StreetCare/StreetCare/Views/Screens/Visit Log/VisitImpactView.swift
@@ -31,6 +31,9 @@ struct VisitImpactView: View {
     @State private var showCustomAlert = false
     @State private var doNotShowAgain = false
     @AppStorage("hideProvidedHelpAlert") private var hideProvidedHelpAlert: Bool = false
+    
+    @State private var selectedVisit: VisitLog? = nil
+    @State private var showPublicPopup = false
 
 
     var body: some View {
@@ -179,10 +182,12 @@ struct VisitImpactView: View {
                                             .foregroundColor(.black)
                                             .padding(.trailing, -5)
                                         Text("\(item.whenVisit.formatted(date: .abbreviated, time: .omitted)) | \(item.whenVisit.formatted(date: .omitted, time: .shortened))").font(.system(size: 13)).lineLimit(1).layoutPriority(1)
-                                        GeometryReader { geo in
-                                            ZStack {
+//                                        GeometryReader { geo in
+//                                            ZStack {
                                                 Button("Details") {
                                                     print("Details tapped")
+                                                    selectedVisit = item
+                                                    showPublicPopup = true
                                                 }
                                                 .font(.custom("Poppins-SemiBold", size: 13))
                                                 .foregroundColor(Color(red: 1.0, green: 0.933, blue: 0.0)) // textColor
@@ -195,17 +200,17 @@ struct VisitImpactView: View {
                                                 .frame(width: 80)
                                                 
                                                 
-                                                NavigationLink(destination: VisitLogView(log: item)) {
-                                                    EmptyView()
-                                                }
-                                                .opacity(0)
-                                            }
-                                            .position(
-                                                x: geo.size.width / 2 ,
-                                                y: 0
-                                            )
-                                        }
-                                        .frame(height: 30) //room you want for the button
+//                                                NavigationLink(destination: VisitLogView(log: item)) {
+//                                                    EmptyView()
+//                                                }
+//                                                .opacity(0)
+//                                            }
+//                                            .position(
+//                                                x: geo.size.width / 2 ,
+//                                                y: 0
+//                                            )
+//                                        }
+//                                        .frame(height: 30) //room you want for the button
                                         
                                     }
                                     .padding(.top, -5)
@@ -251,6 +256,30 @@ struct VisitImpactView: View {
                         itemsDonated = 0
                     }
                 }
+                .bottomSheet(isPresented: $showPublicPopup, content:  {
+                    if let visit = selectedVisit {
+                        PublicInteractionPopupView(
+                            name: user?.displayName ?? "Firstname Lastname",
+                            profileImageURL: user?.photoURL,
+                            date: visit.whenVisit,
+                            address: visit.whereVisit,
+                            interactionDescription: visit.otherNotes ?? "N/A", // have to check
+                            
+                            peopleHelped: visit.peopleHelped, // q3
+                            joinedPeople: visit.numberOfHelpers,
+                            itemsDonated: visit.itemQty, // q4
+                            
+                            helpType: visit.whatGiven,
+                            onCancel: {
+                                showPublicPopup = false
+                            },
+                            delegate: self
+                        )
+                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal)
+                    }
+                }, heightRatio: 0.65)
+
             }
             if showCustomAlert {
                 Color.black.opacity(0.4)
@@ -412,6 +441,12 @@ extension VisitImpactView: VisitLogDataAdapterProtocol {
         self.history = logs
         self.updateCounts()
         self.isLoading = false
+    }
+}
+
+extension VisitImpactView: EventPopupViewDelegate {
+    func close() {
+        showPublicPopup = false
     }
 }
 


### PR DESCRIPTION
Added Event Flagging Logic and Improved User Permissions in Popups

- Implemented conditional flag/unflag logic for events:
    - Only the user who flagged an event or a "Street Care Hub Leader" can unflag it.
    - Displays an alert if unauthorized users attempt to unflag.

- Updated `EventPopupView` and  added `PublicInteractionPopupView`:
    - Show appropriate flag and verification icons based on user type and event state.

- Added role-based icon color coding for user types:
    - Chapter Leader
    - Hub Leader
    - Member
    - Account Holder

- Improved popup user experience and error handling.